### PR TITLE
Allow the file extension of handle bar templates to be customized

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>net.unit8.maven.plugins</groupId>
 	<artifactId>handlebars-maven-plugin</artifactId>
-	<version>0.1.1</version>
+	<version>0.1.2</version>
 	<name>handlebars-maven-plugin</name>
 	<description>The maven plugin for precompiling handlbars.js templates.</description>
 	<packaging>maven-plugin</packaging>

--- a/src/main/java/net/unit8/maven/plugins/handlebars/PrecompileMojo.java
+++ b/src/main/java/net/unit8/maven/plugins/handlebars/PrecompileMojo.java
@@ -29,7 +29,11 @@ import org.mozilla.javascript.ScriptableObject;
  *
  */
 public class PrecompileMojo extends AbstractMojo {
-	private static final String[] TEMPLATE_EXTENSIONS = {"html"};
+	
+	/**
+	 * @parameter
+	 */
+	private String[] templateExtensions;
 
 	/**
 	 * @parameter expression="${encoding}" default-value="UTF-8"
@@ -64,6 +68,9 @@ public class PrecompileMojo extends AbstractMojo {
 		}
 		if (preserveHierarchy == null)
 			preserveHierarchy = true;
+			
+		if (templateExtensions == null)
+			templateExtensions = new String[]{"html"};
 
 		try {
 			visit(sourceDirectory);
@@ -81,7 +88,7 @@ public class PrecompileMojo extends AbstractMojo {
 	}
 
 	protected void precompile(File directory) throws IOException {
-		Collection<File> templates = FileUtils.listFiles(directory, TEMPLATE_EXTENSIONS, false);
+		Collection<File> templates = FileUtils.listFiles(directory, templateExtensions, false);
 		if (templates.isEmpty())
 			return;
 


### PR DESCRIPTION
We use "hb" or "handlebars" as the extension of our templates.

<configuration>
    ...
    <templateExtensions>
         <param>hb</param>
         <param>handlebars</param>
    </templateExtensions>
    ...
</configuration>
